### PR TITLE
fix: check for breaking change indicator in PR title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 build
 .idea
+*.iml

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,9 @@ inputs:
     default: "true"
 outputs:
   labels:
-    description: Generated labels for your pull request.
+    description: Generated space delimited labels for your pull request.
+  labels_list:
+    description: Generated labels for your pull request in list form.
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   access_token:
     description: Github Access Token to access and modify your pr's label
     required: true
+  strict:
+    description: Validate all commit messages use conventional commit standard
+    required: false
+    default: "true"
 outputs:
   labels:
     description: Generated labels for your pull request.

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,10 @@ Conventional labeler will label your PR based on your PR's feature if it follows
 
 - access_token: can be set by using `${{ secrets.GITHUB_TOKEN }}`
 
+## Optional input
+
+- strict: can be set to validate commit messages in addition to the PR title; defaults to true
+
 ## Example
 ```yaml
   label:
@@ -18,6 +22,7 @@ Conventional labeler will label your PR based on your PR's feature if it follows
         uses: action-runner/conventional-labeler@v1
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
+          strict: "true"
       - name: Get the output
         run: echo "The labels were ${{ steps.label.outputs.labels }}"
 

--- a/src/client/conventional_commit.ts
+++ b/src/client/conventional_commit.ts
@@ -41,9 +41,9 @@ export class ConventionalCommit {
   }
 
   /**
-   * Get the corresponding label for the commit title
+   * Get the corresponding labels for the commit title
    */
-  getLabel(message: string): { label?: string; error?: string } {
+  getLabels(message: string): { labels?: string[]; error?: string } {
     // if message is empty, return error
     if (message.length === 0) {
       return { error: "commit message is empty" };
@@ -64,9 +64,15 @@ export class ConventionalCommit {
     );
 
     const matchedLabel = match![1];
-    const label = this.map[matchedLabel].concat(match![2] != null ? "!" : "");
+    const label = this.map[matchedLabel];
+    var labels = [label];
+
+    if (match![2] != null) {
+      labels.push("breaking");
+    }
+
     return {
-      label: label,
+      labels: labels,
     };
   }
 

--- a/src/client/conventional_commit.ts
+++ b/src/client/conventional_commit.ts
@@ -116,16 +116,24 @@ export class ConventionalCommit {
   /**
    * Validate commit messages based on the conventional commit format.
    * The following rules will be applied:
-   * (1): If only one message and it is not equal to the title of the PR, return error
-   * (2): Otherwise, if the message is not in the conventional commit format, return error
+   * (1): If not strict, messages won't be validated
+   * (2): Otherwise if only one message and it is not equal to the title of the PR, return error
+   * (3): Otherwise, if any message is not in the conventional commit format, return error
    *
    * @param messages commit messages
+   * @param title PR title
+   * @param strict whether strict message checking should apply
    * @returns an error message if the commit messages are not valid, otherwise return undefined
    */
-  validate(messages: string[], title: string): string | undefined {
+  validate(messages: string[], title: string, strict: boolean = true): string | undefined {
     // Check if title meets the conventional commit format
     if (!this.validateMessage(title)) {
       return `title [${title}] does not follow the conventional commit format`;
+    }
+
+    // If not in strict mode, no more work needs to be done
+    if (!strict) {
+      return undefined;
     }
 
     if (messages.length === 0) {

--- a/src/client/conventional_commit.ts
+++ b/src/client/conventional_commit.ts
@@ -13,7 +13,6 @@ export class ConventionalCommit {
     test: "test",
     chore: "chore",
     build: "build",
-    breaking: "breaking"
   };
 
   /**
@@ -64,9 +63,10 @@ export class ConventionalCommit {
       /^(feat|fix|docs|style|refactor|perf|test|chore|build)(?:\([\w\s]+\))?(!)?: /
     );
 
-    const matchedLabel = match![2] != null ? "breaking" : match![1];
+    const matchedLabel = match![1];
+    const label = this.map[matchedLabel].concat(match![2] != null ? "!" : "");
     return {
-      label: this.map[matchedLabel],
+      label: label,
     };
   }
 

--- a/src/client/conventional_commit.ts
+++ b/src/client/conventional_commit.ts
@@ -13,6 +13,7 @@ export class ConventionalCommit {
     test: "test",
     chore: "chore",
     build: "build",
+    breaking: "breaking"
   };
 
   /**
@@ -26,7 +27,7 @@ export class ConventionalCommit {
       {
         name: "title",
         regex:
-          /^(feat|fix|docs|style|refactor|perf|test|chore|build)(\(([\w\s]+)\))?: /,
+          /^(feat|fix|docs|style|refactor|perf|test|chore|build)(?:\([\w\s]+\))?(!)?: /,
       },
     ];
 
@@ -60,10 +61,10 @@ export class ConventionalCommit {
 
     // get the label
     const match = message.match(
-      /^(feat|fix|docs|style|refactor|perf|test|chore|build)(\(([\w\s]+)\))?: /
+      /^(feat|fix|docs|style|refactor|perf|test|chore|build)(?:\([\w\s]+\))?(!)?: /
     );
 
-    const matchedLabel = match![1];
+    const matchedLabel = match![2] != null ? "breaking" : match![1];
     return {
       label: this.map[matchedLabel],
     };

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -5,11 +5,14 @@ import * as core from "@actions/core";
 export class ConventionalLabeler {
   private githubClient: GithubClient;
   private conventionalCommit: ConventionalCommit;
+  private strict: boolean;
 
   constructor() {
     const token = core.getInput("access_token", { required: true });
+
     this.githubClient = new GithubClient(token);
     this.conventionalCommit = new ConventionalCommit();
+    this.strict = core.getBooleanInput(token);
   }
 
   /**
@@ -53,7 +56,8 @@ export class ConventionalLabeler {
     }
     const validationError = this.conventionalCommit.validate(
       commitMessages.commitMessages!,
-      title
+      title,
+      this.strict
     );
     if (validationError) {
       core.setFailed(validationError);

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -18,7 +18,7 @@ export class ConventionalLabeler {
   /**
    * Label the pr based on the title
    */
-  async label() {
+  async labels() {
     // get pr's number
     core.info("Getting PR number");
     const pr = this.githubClient.getPr();
@@ -66,15 +66,15 @@ export class ConventionalLabeler {
 
     // get the generated label
     core.info(`Getting conventional label from title ${title}`);
-    const generatedLabel = this.conventionalCommit.getLabel(title);
-    if (generatedLabel.error) {
-      core.setFailed(generatedLabel.error);
+    const generatedLabels = this.conventionalCommit.getLabels(title);
+    if (generatedLabels.error) {
+      core.setFailed(generatedLabels.error);
       return;
     }
 
     const differentLabels = this.conventionalCommit.getDiffLabels(
       predefinedLabels,
-      [generatedLabel.label!]
+      generatedLabels.labels!
     );
 
     // remove the labels that are not in the preset labels
@@ -89,13 +89,14 @@ export class ConventionalLabeler {
     }
 
     // add the generated label
-    core.info(`Adding label ${generatedLabel.label} to PR`);
-    const error = await this.githubClient.addLabel(pr, [generatedLabel.label!]);
+    core.info(`Adding labels ${generatedLabels!.labels!.join(", ")} to PR`);
+    const error = await this.githubClient.addLabel(pr, generatedLabels.labels!);
     if (error) {
       core.setFailed(error);
       return;
     }
 
-    core.setOutput("labels", generatedLabel.label);
+    core.setOutput("labels", generatedLabels!.labels!.join(" "));
+    core.setOutput("labels_list", generatedLabels.labels);
   }
 }

--- a/src/tests/conventional_commit.test.ts
+++ b/src/tests/conventional_commit.test.ts
@@ -19,6 +19,12 @@ describe("Given a conventional commit client", () => {
     expect(label.label).toEqual("enhancement");
   });
 
+  it("should return the corresponding label for the commit title", () => {
+    const label = client.getLabel("fix!: it is a breaking change");
+    expect(label.error).toBeUndefined();
+    expect(label.label).toEqual("breaking");
+  });
+
   it("should return an error if the commit title is invalid", () => {
     const message = "add test";
     const label = client.getLabel(message);

--- a/src/tests/conventional_commit.test.ts
+++ b/src/tests/conventional_commit.test.ts
@@ -22,7 +22,13 @@ describe("Given a conventional commit client", () => {
   it("should return the corresponding label for the commit title", () => {
     const label = client.getLabel("fix!: it is a breaking change");
     expect(label.error).toBeUndefined();
-    expect(label.label).toEqual("breaking");
+    expect(label.label).toEqual("bug!");
+  });
+
+  it("should return the corresponding label for the commit title", () => {
+    const label = client.getLabel("feat!: it is a breaking change");
+    expect(label.error).toBeUndefined();
+    expect(label.label).toEqual("enhancement!");
   });
 
   it("should return an error if the commit title is invalid", () => {

--- a/src/tests/conventional_commit.test.ts
+++ b/src/tests/conventional_commit.test.ts
@@ -7,50 +7,50 @@ describe("Given a conventional commit client", () => {
     client = new ConventionalCommit();
   });
 
-  it("should return the corresponding label for the commit title", () => {
-    const label = client.getLabel("fix: add a new feature");
-    expect(label.error).toBeUndefined();
-    expect(label.label).toEqual("bug");
+  it("should return the corresponding labels for the commit title", () => {
+    const labels = client.getLabels("fix: add a new feature");
+    expect(labels.error).toBeUndefined();
+    expect(labels.labels).toEqual(["bug"]);
   });
 
-  it("should return the corresponding label for the commit title", () => {
+  it("should return the corresponding labels for the commit title", () => {
     const message = "feat: add test";
-    const label = client.getLabel(message);
-    expect(label.label).toEqual("enhancement");
+    const labels = client.getLabels(message);
+    expect(labels.labels).toEqual(["enhancement"]);
   });
 
-  it("should return the corresponding label for the commit title", () => {
-    const label = client.getLabel("fix!: it is a breaking change");
-    expect(label.error).toBeUndefined();
-    expect(label.label).toEqual("bug!");
+  it("should return the corresponding labels for the commit title", () => {
+    const labels = client.getLabels("fix!: it is a breaking change");
+    expect(labels.error).toBeUndefined();
+    expect(labels.labels).toEqual(["bug","breaking"]);
   });
 
-  it("should return the corresponding label for the commit title", () => {
-    const label = client.getLabel("feat!: it is a breaking change");
-    expect(label.error).toBeUndefined();
-    expect(label.label).toEqual("enhancement!");
+  it("should return the corresponding labels for the commit title", () => {
+    const labels = client.getLabels("feat!: it is a breaking change");
+    expect(labels.error).toBeUndefined();
+    expect(labels.labels).toEqual(["enhancement","breaking"]);
   });
 
   it("should return an error if the commit title is invalid", () => {
     const message = "add test";
-    const label = client.getLabel(message);
-    expect(label.error).toBeDefined();
-    expect(label.label).toBeUndefined();
+    const labels = client.getLabels(message);
+    expect(labels.error).toBeDefined();
+    expect(labels.labels).toBeUndefined();
   });
 
   it("should return an error if the commit title is invalid", () => {
     const message = "";
-    const label = client.getLabel(message);
-    expect(label.error).toBe("commit message is empty");
-    expect(label.label).toBeUndefined();
+    const labels = client.getLabels(message);
+    expect(labels.error).toBe("commit message is empty");
+    expect(labels.labels).toBeUndefined();
   });
 
-  it("Should return true if the label is one of the predefined labels", () => {
+  it("Should return true if the labels is one of the predefined labels", () => {
     const result = client.isConventionalLabel("enhancement");
     expect(result).toBeTruthy();
   });
 
-  it("Should return false if the label is not one of the predefined labels", () => {
+  it("Should return false if the labels is not one of the predefined labels", () => {
     const result = client.isConventionalLabel("enhance");
     expect(result).toBeFalsy();
   });

--- a/src/tests/covnentioanl_commit.test.ts
+++ b/src/tests/covnentioanl_commit.test.ts
@@ -132,4 +132,9 @@ describe("Given a conventional commit client", () => {
     const error = client.validate(["fix: hello\n* a: fix error"], "fix: hello");
     expect(error).toBeUndefined();
   });
+
+  it("Should return no error when not strict", () => {
+    const error = client.validate(["hello", "fix error"], "fix: hello", false);
+    expect(error).toBeUndefined();
+  });
 });

--- a/src/tests/labeler.test.ts
+++ b/src/tests/labeler.test.ts
@@ -52,8 +52,8 @@ describe("Given a labeler client", () => {
     (core.setFailed as any).mockClear();
   });
 
-  it("should return the corresponding label for the commit title", async () => {
-    await client.label();
+  it("should return the corresponding labels for the commit title", async () => {
+    await client.labels();
     expect(core.info).toHaveBeenCalledTimes(7);
   });
 
@@ -76,7 +76,7 @@ describe("Given a labeler client", () => {
         },
       },
     });
-    await client.label();
+    await client.labels();
     expect(core.setFailed).toHaveBeenCalledTimes(1);
     expect(core.setFailed).toHaveBeenCalledWith("Error: add label error");
   });
@@ -100,7 +100,7 @@ describe("Given a labeler client", () => {
         },
       },
     });
-    await client.label();
+    await client.labels();
     expect(core.setFailed).toHaveBeenCalledTimes(1);
     expect(core.setFailed).toHaveBeenCalledWith("Error: remove label error");
   });
@@ -115,14 +115,14 @@ describe("Given a labeler client", () => {
         },
       },
     });
-    await client.label();
+    await client.labels();
     expect(core.setFailed).toHaveBeenCalledTimes(1);
     expect(core.setFailed).toHaveBeenCalledWith("Error: issue error");
   });
 
   it("should return the pr error", async () => {
     (github as any).context.payload.pull_request!.number = undefined;
-    await client.label();
+    await client.labels();
     expect(core.setFailed).toHaveBeenCalledTimes(1);
     expect(core.setFailed).toHaveBeenCalledWith("No pull request found");
   });
@@ -152,7 +152,7 @@ describe("Given a labeler client", () => {
       },
     };
 
-    await client.label();
+    await client.labels();
     expect(core.setFailed).toHaveBeenCalledTimes(1);
     expect(core.setFailed).toHaveBeenCalledWith("Failed to get the pr title");
   });
@@ -185,7 +185,7 @@ describe("Given a labeler client", () => {
       },
     };
 
-    await client.label();
+    await client.labels();
     expect(core.setFailed).toHaveBeenCalledTimes(1);
     expect(core.setFailed).toHaveBeenCalledWith(
       "title [hello] does not follow the conventional commit format"
@@ -222,7 +222,7 @@ describe("Given a labeler client", () => {
       },
     };
 
-    await client.label();
+    await client.labels();
     expect(core.setFailed).toHaveBeenCalledTimes(1);
     expect(core.setFailed).toHaveBeenCalledWith(
       "commit message [fix: hell] does not equal to the title of the PR [fix: hello]"
@@ -262,7 +262,7 @@ describe("Given a labeler client", () => {
       },
     };
 
-    await client.label();
+    await client.labels();
     expect(core.setFailed).toHaveBeenCalledTimes(1);
     expect(core.setFailed).toHaveBeenCalledWith(
       "commit message [hello] does not follow the conventional commit format"
@@ -309,7 +309,7 @@ describe("Given a labeler with predifined labels", () => {
         },
       },
     };
-    await client.label();
+    await client.labels();
     const addCalls = addLabels.mock.calls;
 
     expect(addCalls.length).toBe(1);
@@ -347,7 +347,7 @@ describe("Given a labeler with predifined labels", () => {
         },
       },
     };
-    await client.label();
+    await client.labels();
     const addCalls = addLabels.mock.calls;
 
     expect(removeLabels).toHaveBeenCalledTimes(1);
@@ -384,7 +384,7 @@ describe("Given a labeler with predifined labels", () => {
         },
       },
     };
-    await client.label();
+    await client.labels();
     const addCalls = addLabels.mock.calls;
 
     expect(removeLabels).toHaveBeenCalledTimes(0);
@@ -421,7 +421,7 @@ describe("Given a labeler with predifined labels", () => {
         },
       },
     };
-    await client.label();
+    await client.labels();
     const addCalls = addLabels.mock.calls;
 
     expect(removeLabels).toHaveBeenCalledTimes(0);

--- a/src/tests/labeler.test.ts
+++ b/src/tests/labeler.test.ts
@@ -4,6 +4,7 @@ import { ConventionalLabeler } from "../labeler";
 
 jest.mock("@actions/core", () => ({
   getInput: jest.fn().mockReturnValue("mock_token"),
+  getBooleanInput: jest.fn().mockReturnValue(true),
   info: jest.fn(),
   error: jest.fn(),
   setOutput: jest.fn(),


### PR DESCRIPTION
* Logic wasn't checking for the `!` which indicates a breaking change
* Cleaned up regexes to not capture unneeded groups