### PR TITLE
feat: allow message validation to be optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 build
 .idea
+*.iml

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   access_token:
     description: Github Access Token to access and modify your pr's label
     required: true
+  strict:
+    description: Validate all commit messages use conventional commit standard
+    required: false
+    default: "true"
 outputs:
   labels:
     description: Generated labels for your pull request.

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,10 @@ Conventional labeler will label your PR based on your PR's feature if it follows
 
 - access_token: can be set by using `${{ secrets.GITHUB_TOKEN }}`
 
+## Optional input
+
+- strict: can be set to validate commit messages in addition to the PR title; defaults to true
+
 ## Example
 ```yaml
   label:
@@ -18,6 +22,7 @@ Conventional labeler will label your PR based on your PR's feature if it follows
         uses: action-runner/conventional-labeler@v1
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
+          strict: "true"
       - name: Get the output
         run: echo "The labels were ${{ steps.label.outputs.labels }}"
 

--- a/src/client/conventional_commit.ts
+++ b/src/client/conventional_commit.ts
@@ -116,16 +116,24 @@ export class ConventionalCommit {
   /**
    * Validate commit messages based on the conventional commit format.
    * The following rules will be applied:
-   * (1): If only one message and it is not equal to the title of the PR, return error
-   * (2): Otherwise, if the message is not in the conventional commit format, return error
+   * (1): If not strict, messages won't be validated
+   * (2): Otherwise if only one message and it is not equal to the title of the PR, return error
+   * (3): Otherwise, if any message is not in the conventional commit format, return error
    *
    * @param messages commit messages
+   * @param title PR title
+   * @param strict whether strict message checking should apply
    * @returns an error message if the commit messages are not valid, otherwise return undefined
    */
-  validate(messages: string[], title: string): string | undefined {
+  validate(messages: string[], title: string, strict: boolean = true): string | undefined {
     // Check if title meets the conventional commit format
     if (!this.validateMessage(title)) {
       return `title [${title}] does not follow the conventional commit format`;
+    }
+
+    // If not in strict mode, no more work needs to be done
+    if (!strict) {
+      return undefined;
     }
 
     if (messages.length === 0) {

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -12,7 +12,7 @@ export class ConventionalLabeler {
 
     this.githubClient = new GithubClient(token);
     this.conventionalCommit = new ConventionalCommit();
-    this.strict = core.getBooleanInput(token);
+    this.strict = core.getBooleanInput("strict");
   }
 
   /**

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -5,11 +5,14 @@ import * as core from "@actions/core";
 export class ConventionalLabeler {
   private githubClient: GithubClient;
   private conventionalCommit: ConventionalCommit;
+  private strict: boolean;
 
   constructor() {
     const token = core.getInput("access_token", { required: true });
+
     this.githubClient = new GithubClient(token);
     this.conventionalCommit = new ConventionalCommit();
+    this.strict = core.getBooleanInput(token);
   }
 
   /**
@@ -53,7 +56,8 @@ export class ConventionalLabeler {
     }
     const validationError = this.conventionalCommit.validate(
       commitMessages.commitMessages!,
-      title
+      title,
+      this.strict
     );
     if (validationError) {
       core.setFailed(validationError);

--- a/src/tests/covnentioanl_commit.test.ts
+++ b/src/tests/covnentioanl_commit.test.ts
@@ -132,4 +132,9 @@ describe("Given a conventional commit client", () => {
     const error = client.validate(["fix: hello\n* a: fix error"], "fix: hello");
     expect(error).toBeUndefined();
   });
+
+  it("Should return no error when not strict", () => {
+    const error = client.validate(["hello", "fix error"], "fix: hello", false);
+    expect(error).toBeUndefined();
+  });
 });

--- a/src/tests/labeler.test.ts
+++ b/src/tests/labeler.test.ts
@@ -4,6 +4,7 @@ import { ConventionalLabeler } from "../labeler";
 
 jest.mock("@actions/core", () => ({
   getInput: jest.fn().mockReturnValue("mock_token"),
+  getBooleanInput: jest.fn().mockReturnValue(true),
   info: jest.fn(),
   error: jest.fn(),
   setOutput: jest.fn(),


### PR DESCRIPTION
For PR workflows which force a squash and merge, it's not necessarily useful for the intermediary commit messages to follow conventional commits.  This PR adds a `strict` input (defaults to `true` for backwards compatibility) which, when set to false, allows validation to only apply to the PR title.